### PR TITLE
Feature/requirecleanworkingtree

### DIFF
--- a/build/Dotnet.Build.nuspec
+++ b/build/Dotnet.Build.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Dotnet.Build</id>
     <title>Dotnet.Build</title>
-    <version>0.2.4</version>
+    <version>0.2.5</version>
     <description>Just a collection of dotnet-script compatible scripts to be used in build scripts.</description>
     <authors>Bernhard Richter</authors>
     <owners>Bernhard Richter</owners>

--- a/build/Dotnet.Build.nuspec
+++ b/build/Dotnet.Build.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Dotnet.Build</id>
     <title>Dotnet.Build</title>
-    <version>0.2.3</version>
+    <version>0.2.4</version>
     <description>Just a collection of dotnet-script compatible scripts to be used in build scripts.</description>
     <authors>Bernhard Richter</authors>
     <owners>Bernhard Richter</owners>

--- a/build/build.csx
+++ b/build/build.csx
@@ -50,6 +50,7 @@ if (BuildEnvironment.IsSecure)
 
     if (Git.Default.IsTagCommit())
     {
+        Git.Default.RequreCleanWorkingTree();
         await ReleaseManagerFor("seesharper", "dotnet-build", accessToken)
             .CreateRelease(Git.Default.GetLatestTag(), pathToReleaseNotes, Array.Empty<ReleaseAsset>());
         NuGet.Push(pathToNuGetArtifacts);

--- a/src/Dotnet.Build.Tests/DotNetTests.csx
+++ b/src/Dotnet.Build.Tests/DotNetTests.csx
@@ -7,7 +7,7 @@
 #load "TestUtils.csx"
 
 
-
+using FluentAssertions;
 using static ScriptUnit;
 using static FileUtils;
 
@@ -35,7 +35,7 @@ public class DotNetTests
         }
     }
     
-    [OnlyThis]
+    
     public void ShouldExecuteScriptTests()
     {
         using(var projectFolder = new DisposableFolder())
@@ -52,6 +52,20 @@ public class DotNetTests
         {
             Command.Execute("dotnet",$"new console -o {projectFolder.Path}");
             DotNet.Publish(projectFolder.Path);
+        }
+    }
+
+    [OnlyThis]
+    public void ShouldPublishToGivenFolder()
+    {
+        using(var projectFolder = new DisposableFolder())
+        {
+            using(var outputFolder = new DisposableFolder())
+            {
+                Command.Execute("dotnet",$"new console -o {projectFolder.Path}");
+                DotNet.Publish(projectFolder.Path, outputFolder.Path);
+                Directory.GetFiles(outputFolder.Path, "*.dll").Should().NotBeEmpty();
+            }
         }
     }
 }

--- a/src/Dotnet.Build.Tests/GitTests.csx
+++ b/src/Dotnet.Build.Tests/GitTests.csx
@@ -3,6 +3,7 @@
 #load "../Dotnet.Build/Git.csx"
 #load "../Dotnet.Build/Command.csx"
 #load "../Dotnet.Build/FileUtils.csx"
+#load "TestUtils.csx"
 #load "nuget:ScriptUnit, 0.1.3"
 
 
@@ -69,13 +70,13 @@ public class GitTests
             repo.HasUntrackedFiles().Should().BeFalse();
         }
     }
+        
     
     public void ShouldDetectStagedFiles()
     {
         using (var folder = new DisposableFolder())
         {            
-            var repo = folder.Init();
-            repo.HasStagedFiles().Should().BeFalse();
+            var repo = folder.Init();            
             File.Create(Path.Combine(folder.Path,"README.MD")).Close();            
             repo.Execute("add .");
             repo.HasStagedFiles().Should().BeTrue();
@@ -83,7 +84,20 @@ public class GitTests
             repo.HasStagedFiles().Should().BeFalse();
         }
     }
-
+    [OnlyThis]
+    public void ShouldDetectUnstagedFiles()
+    {
+        using (var folder = new DisposableFolder())
+        {            
+            var repo = folder.Init();            
+            File.Create(Path.Combine(folder.Path,"README.MD")).Close();                        
+            repo.Execute("add .");
+            repo.Execute("commit -m \"Added file \"");
+            repo.HasUnstagedFiles().Should().BeFalse();
+            File.WriteAllText(Path.Combine(folder.Path,"README.MD"),"TEST");
+            repo.HasUnstagedFiles().Should().BeTrue();         
+        }
+    }
     public void ShouldGetRemoteTags()
     {
         

--- a/src/Dotnet.Build/DotNet.csx
+++ b/src/Dotnet.Build/DotNet.csx
@@ -42,10 +42,15 @@ public static class DotNet
         Command.Execute("dotnet","build " + pathToProjectFile + " --configuration Release");  
     }
 
-    public static void Publish(string pathToProjectFolder)
+    public static void Publish(string pathToProjectFolder, string outputFolder = null)
     {
          string pathToProjectFile = FindProjectFile(pathToProjectFolder);
-         Command.Execute("dotnet","publish " + pathToProjectFile + " --configuration Release");
+         var args = $"publish {pathToProjectFile} --configuration Release";
+         if (!string.IsNullOrWhiteSpace(outputFolder))
+         {
+             args = args + $" --output {outputFolder}";
+         }
+         Command.Execute("dotnet", args);
     }
 
     private static string FindProjectFile(string pathToProjectFolder)


### PR DESCRIPTION
This PR adds the `RequreCleanWorkingTree` to the `GitRepository` class. This is to be used to ensure that we don't have any local changes before for instance creating a new release.