### PR TITLE
Added support for updating GitHub releases

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "program": "dotnet",
             "args": [
               "exec", 
-              "C:/ProgramData/dotnet-script/dotnet-script/dotnet-script.dll", 
+              "C:/ProgramData/chocolatey/lib/dotnet.script/Dotnet.Script/dotnet-script.dll", 
               "${file}"
             ],
             "cwd": "${workspaceRoot}",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ artifacts:
 
 test: off
 environment:
-    IS_SECURE_BUILDENVIRONMENT:
+    IS_SECURE_BUILDENVIRONM∥ENT:
         secure: xYC5jpSucUdHr8YwfxWefw==
     GITHUB_REPO_TOKEN:
         secure: FSPXTPuTgFMaZA7DubJoX217SkWhFLN2BGqCCi4gBux967eFtwkhbrafm7ay8cP2

--- a/build/Dotnet.Build.nuspec
+++ b/build/Dotnet.Build.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Dotnet.Build</id>
     <title>Dotnet.Build</title>
-    <version>0.2.7</version>
+    <version>0.2.8</version>
     <description>Just a collection of dotnet-script compatible scripts to be used in build scripts.</description>
     <authors>Bernhard Richter</authors>
     <owners>Bernhard Richter</owners>

--- a/src/Dotnet.Build.Tests/AllTests.csx
+++ b/src/Dotnet.Build.Tests/AllTests.csx
@@ -4,6 +4,7 @@
 #load "../Dotnet.Build.Tests/DotNetTests.csx"
 #load "../Dotnet.Build.Tests/LoggerTests.csx"
 #load "../Dotnet.Build.Tests/FileUtilsTests.csx"
+#load "../Dotnet.Build.Tests/GitHub-ReleaseManagerTests.csx"
 #load "nuget:ScriptUnit, 0.1.3"
 
 using static ScriptUnit; 
@@ -14,4 +15,5 @@ return await
     .AddTestsFrom<GitTests>()
     .AddTestsFrom<LoggerTests>()
     .AddTestsFrom<FileUtilsTests>()
+    .AddTestsFrom<ReleaseManagerTests>()
     .Execute();

--- a/src/Dotnet.Build.Tests/AllTests.csx
+++ b/src/Dotnet.Build.Tests/AllTests.csx
@@ -5,15 +5,19 @@
 #load "../Dotnet.Build.Tests/LoggerTests.csx"
 #load "../Dotnet.Build.Tests/FileUtilsTests.csx"
 #load "../Dotnet.Build.Tests/GitHub-ReleaseManagerTests.csx"
+#load "../Dotnet.Build/BuildEnvironment.csx"
 #load "nuget:ScriptUnit, 0.1.3"
 
 using static ScriptUnit; 
 
-return await 
-     AddTestsFrom<CommandTests>()
+var testRunner = AddTestsFrom<CommandTests>()
     .AddTestsFrom<DotNetTests>()
     .AddTestsFrom<GitTests>()
     .AddTestsFrom<LoggerTests>()
-    .AddTestsFrom<FileUtilsTests>()
-    .AddTestsFrom<ReleaseManagerTests>()
-    .Execute();
+    .AddTestsFrom<FileUtilsTests>();
+if (BuildEnvironment.IsSecure)
+{
+    testRunner = testRunner.AddTestsFrom<ReleaseManagerTests>();
+}        
+
+return await testRunner.Execute();

--- a/src/Dotnet.Build.Tests/GitHub-ReleaseManagerTests.csx
+++ b/src/Dotnet.Build.Tests/GitHub-ReleaseManagerTests.csx
@@ -1,0 +1,163 @@
+#! "netcoreapp2.0"
+#r "nuget: FluentAssertions, 4.19.4"
+#r "nuget:Octokit, 0.27.0"
+#load "../Dotnet.Build/FileUtils.csx"
+#load "../Dotnet.Build/GitHub-ReleaseManager.csx"
+#load "nuget:ScriptUnit, 0.1.3"
+#load "TestUtils.csx"
+
+using Octokit;
+using FluentAssertions;
+using static ReleaseManagement;
+using static FileUtils;
+using static ScriptUnit;
+
+// await AddTestsFrom<ReleaseManagerTests>().AddFilter(m => m.IsDefined(typeof(OnlyThisAttribute), true)).Execute();
+// await AddTestsFrom<ReleaseManagerTests>().Execute();
+
+public class ReleaseManagerTests
+{
+    private static string Owner = "seesharper";
+    private static string Repository = "release-fixture";
+
+    
+    public async Task ShouldCreateRelease()
+    {
+        var accessToken = System.Environment.GetEnvironmentVariable("GITHUB_REPO_TOKEN");
+        var client = CreateClient();
+        await DeleteAllReleases(client);
+
+        using (var disposableFolder = new DisposableFolder())
+        {
+            var pathToReleaseNotes = Path.Combine(disposableFolder.Path, "ReleaseNotes.md");
+            File.WriteAllText(pathToReleaseNotes, "This is some release notes");
+            await ReleaseManagerFor(Owner, Repository, accessToken).CreateRelease("0.1.0", pathToReleaseNotes, new[] { new ZipReleaseAsset(pathToReleaseNotes) });
+        }
+
+        var latestRelease = await client.Repository.Release.GetLatest(Owner, Repository);
+        latestRelease.Name.Should().Be("0.1.0");
+        latestRelease.Body.Should().Be("This is some release notes");
+    }
+
+   
+    public async Task ShouldUpdateReleaseBodyIfEmpty()
+    {
+        var accessToken = System.Environment.GetEnvironmentVariable("GITHUB_REPO_TOKEN");
+        var client = CreateClient();
+        await DeleteAllReleases(client);
+
+        var newRelease = new NewRelease("0.1.0");
+        newRelease.Name = "Release Name";
+        await client.Repository.Release.Create(Owner, Repository, newRelease);
+
+        using (var disposableFolder = new DisposableFolder())
+        {
+            var pathToReleaseNotes = Path.Combine(disposableFolder.Path, "ReleaseNotes.md");
+            File.WriteAllText(pathToReleaseNotes, "This is some release notes");
+            await ReleaseManagerFor(Owner, Repository, accessToken).CreateRelease("0.1.0", pathToReleaseNotes, new[] { new ZipReleaseAsset(pathToReleaseNotes) });
+        }
+        
+        var latestRelease = await client.Repository.Release.GetLatest(Owner, Repository);
+        latestRelease.Name.Should().Be("Release Name");
+        latestRelease.Body.Should().Be("This is some release notes");
+        
+    }
+
+   
+    public async Task ShouldNotUpdateReleaseBodyIfNotEmpty()
+    {
+        var accessToken = System.Environment.GetEnvironmentVariable("GITHUB_REPO_TOKEN");
+        var client = CreateClient();
+        await DeleteAllReleases(client);
+
+        var newRelease = new NewRelease("0.1.0");
+        newRelease.Name = "Release Name";
+        newRelease.Body = "Release Body";
+        await client.Repository.Release.Create(Owner, Repository, newRelease);
+
+        using (var disposableFolder = new DisposableFolder())
+        {
+            var pathToReleaseNotes = Path.Combine(disposableFolder.Path, "ReleaseNotes.md");
+            File.WriteAllText(pathToReleaseNotes, "This is some release notes");
+            await ReleaseManagerFor(Owner, Repository, accessToken).CreateRelease("0.1.0", pathToReleaseNotes, new[] { new ZipReleaseAsset(pathToReleaseNotes) });
+        }
+        
+        var latestRelease = await client.Repository.Release.GetLatest(Owner, Repository);
+        latestRelease.Name.Should().Be("Release Name");
+        latestRelease.Body.Should().Be("Release Body");
+        
+    }
+     
+     
+     public async Task ShouldUpdateNameIfEmpty()
+    {
+        var accessToken = System.Environment.GetEnvironmentVariable("GITHUB_REPO_TOKEN");
+        var client = CreateClient();
+        await DeleteAllReleases(client);
+
+        var newRelease = new NewRelease("0.1.0");
+        newRelease.Name = "";
+        newRelease.Body = "This is some release notes";
+        await client.Repository.Release.Create(Owner, Repository, newRelease);
+
+        using (var disposableFolder = new DisposableFolder())
+        {
+            var pathToReleaseNotes = Path.Combine(disposableFolder.Path, "ReleaseNotes.md");
+            File.WriteAllText(pathToReleaseNotes, "This is some release notes");
+            await ReleaseManagerFor(Owner, Repository, accessToken).CreateRelease("0.1.0", pathToReleaseNotes, new[] { new ZipReleaseAsset(pathToReleaseNotes) });
+        }
+        
+        var latestRelease = await client.Repository.Release.GetLatest(Owner, Repository);
+        latestRelease.Name.Should().Be("0.1.0");
+        latestRelease.Body.Should().Be("This is some release notes");
+        
+    }
+
+    
+    public async Task ShouldNotUpdateNameIfNotEmpty()
+    {
+        var accessToken = System.Environment.GetEnvironmentVariable("GITHUB_REPO_TOKEN");
+        var client = CreateClient();
+        await DeleteAllReleases(client);
+
+        var newRelease = new NewRelease("0.1.0");
+        newRelease.Name = "Release Name";
+        newRelease.Body = "This is some release notes";
+        await client.Repository.Release.Create(Owner, Repository, newRelease);
+
+        using (var disposableFolder = new DisposableFolder())
+        {
+            var pathToReleaseNotes = Path.Combine(disposableFolder.Path, "ReleaseNotes.md");
+            File.WriteAllText(pathToReleaseNotes, "This is some release notes");
+            await ReleaseManagerFor(Owner, Repository, accessToken).CreateRelease("0.1.0", pathToReleaseNotes, new[] { new ZipReleaseAsset(pathToReleaseNotes) });
+        }
+        
+        var latestRelease = await client.Repository.Release.GetLatest(Owner, Repository);
+        latestRelease.Name.Should().Be("Release Name");
+        latestRelease.Body.Should().Be("This is some release notes");
+        
+    }
+
+
+    private static GitHubClient CreateClient()
+    {
+        var accessToken = System.Environment.GetEnvironmentVariable("GITHUB_REPO_TOKEN");
+
+        var client = new GitHubClient(new ProductHeaderValue("release-fixture"));
+        var tokenAuth = new Credentials(accessToken);
+        client.Credentials = tokenAuth;
+        return client;
+    }
+
+    private static async Task DeleteAllReleases(GitHubClient client)
+    {
+        var allReleases = await client.Repository.Release.GetAll(Owner, Repository);
+        foreach (var release in allReleases)
+        {
+            await client.Repository.Release.Delete(Owner, Repository, release.Id);
+        }
+    }
+
+
+
+}


### PR DESCRIPTION
This PR adds support for updating GitGub releases. If we try to create a release that already exists, we will update the name and body if they are empty. Assets are uploaded regardless. 