### PR TITLE
Pass excludefolders to Copy method

### DIFF
--- a/build/Dotnet.Build.nuspec
+++ b/build/Dotnet.Build.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Dotnet.Build</id>
     <title>Dotnet.Build</title>
-    <version>0.3.7</version>
+    <version>0.3.8</version>
     <description>Just a collection of dotnet-script compatible scripts to be used in build scripts.</description>
     <authors>Bernhard Richter</authors>
     <owners>Bernhard Richter</owners>

--- a/src/Dotnet.Build/FileUtils.csx
+++ b/src/Dotnet.Build/FileUtils.csx
@@ -105,7 +105,7 @@ public static class FileUtils
                 var directoryName = Path.GetFileName(directory);
                 if (!excludeFolders.Contains(directoryName))
                 {
-                    Copy(directory, Path.Combine(targetPath, Path.GetFileName(directory)));
+                    Copy(directory, Path.Combine(targetPath, Path.GetFileName(directory)), excludeFolders);
                 }                
             }
         }


### PR DESCRIPTION
Fixes a bug where the `exclkudeFolders` were not pass to the `Copy` method.