### PR TITLE
use dotnet nuget push

### DIFF
--- a/build/Dotnet.Build.nuspec
+++ b/build/Dotnet.Build.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Dotnet.Build</id>
     <title>Dotnet.Build</title>
-    <version>0.8.1</version>
+    <version>0.9.0</version>
     <description>Just a collection of dotnet-script compatible scripts to be used in build scripts.</description>
     <authors>Bernhard Richter</authors>
     <owners>Bernhard Richter</owners>

--- a/build/build.csx
+++ b/build/build.csx
@@ -51,7 +51,7 @@ if (BuildEnvironment.IsSecure)
         Git.Default.RequireCleanWorkingTree();
         await ReleaseManagerFor("seesharper", "dotnet-build", accessToken)
             .CreateRelease(Git.Default.GetLatestTag(), pathToReleaseNotes, Array.Empty<ReleaseAsset>());
-        NuGet.Push(pathToNuGetArtifacts);
+        DotNet.Push(pathToNuGetArtifacts);
     }
 }
 

--- a/src/Dotnet.Build/Artifacts.csx
+++ b/src/Dotnet.Build/Artifacts.csx
@@ -2,7 +2,7 @@
 #load "BuildContext.csx"
 #load "GitHub.csx"
 #load "Git.csx"
-#load "NuGet.csx"
+#load "DotNet.csx"
 public static class Artifacts
 {
     public async static Task Deploy()
@@ -25,7 +25,7 @@ public static class Artifacts
 
         await GitHub.Release();
 
-        NuGet.TryPush();
+        DotNet.TryPush();
 
     }
 }

--- a/src/Dotnet.Build/DotNet.csx
+++ b/src/Dotnet.Build/DotNet.csx
@@ -8,6 +8,10 @@ using static FileUtils;
 
 public static class DotNet
 {
+    private const string DefaultSource = "https://www.nuget.org/api/v2/package";
+
+    private static string NuGetApiKey = System.Environment.GetEnvironmentVariable("NUGET_APIKEY");
+
     /// <summary>
     /// Executes the tests in the given path. The path may the full path to a csproj file
     /// that represents a test project or it may be the
@@ -103,6 +107,36 @@ public static class DotNet
         string pathToProjectFile = FindProjectFile(pathToProjectFolder);
         Command.Execute("dotnet", $"pack {pathToProjectFile} --configuration Release --output {pathToPackageOutputFolder} {commitHash}");
     }
+
+    public static void Push(string packagesFolder, string source = DefaultSource)
+    {
+        var packageFiles = Directory.GetFiles(packagesFolder, "*.nupkg");
+        foreach (var packageFile in packageFiles)
+        {
+            Command.Execute("dotnet", $"nuget push {packageFile} --source {source} --api-key {NuGetApiKey}");
+        }
+    }
+
+    public static void Push()
+    {
+        Push(BuildContext.NuGetArtifactsFolder);
+    }
+
+
+    public static void TryPush(string packagesFolder, string source = DefaultSource)
+    {
+        var packageFiles = Directory.GetFiles(packagesFolder, "*.nupkg");
+        foreach (var packageFile in packageFiles)
+        {
+            Command.Capture("dotnet", $"nuget push {packageFile} --source {source} --api-key {NuGetApiKey}").Dump();
+        }
+    }
+
+    public static void TryPush()
+    {
+        TryPush(BuildContext.NuGetArtifactsFolder);
+    }
+
 
     public static void Build(string pathToProjectFolder)
     {

--- a/src/Dotnet.Build/NuGet.csx
+++ b/src/Dotnet.Build/NuGet.csx
@@ -14,33 +14,12 @@ public static class NuGet
 
     private static string ApiKey = System.Environment.GetEnvironmentVariable("NUGET_APIKEY");
 
-    public static void Push(string packagesFolder, string source = DefaultSource)
-    {
-        var packageFiles = Directory.GetFiles(packagesFolder, "*.nupkg");
-        foreach (var packageFile in packageFiles)
-        {
-            Command.Execute("nuget", $"push {packageFile} -Source {source} -ApiKey {ApiKey}");
-        }
-    }
-
     public static void Install(string packageName, string outputDirectory)
     {
         Command.Execute("nuget", $"install {packageName} -OutputDirectory {outputDirectory}", ".");
     }
 
-    public static void TryPush(string packagesFolder, string source = DefaultSource)
-    {
-        var packageFiles = Directory.GetFiles(packagesFolder, "*.nupkg");
-        foreach (var packageFile in packageFiles)
-        {
-            Command.Capture("nuget", $"push {packageFile} -Source {source} -ApiKey {ApiKey}").Dump();
-        }
-    }
 
-    public static void TryPush()
-    {
-        TryPush(BuildContext.NuGetArtifactsFolder);
-    }
     public static void Pack(string pathToMetadataFolder, string outputFolder, string version = "")
     {
         string versionArgument = "";


### PR DESCRIPTION
This PR adds support for `dotnet nuget push` so that we don't need `NuGet.exe` for pushing to NuGet.