### PR TITLE
Teach GitRepository.GetLatestTagHash() relativity

### DIFF
--- a/src/Dotnet.Build.Tests/GitTests.csx
+++ b/src/Dotnet.Build.Tests/GitTests.csx
@@ -62,6 +62,60 @@ public class GitTests
         }
     }
 
+    public void ShouldGetLatestTagForCurrentCheckout()
+    {
+        using (var folder = new DisposableFolder())
+        {
+            var repo = folder.Init();
+            repo.Execute("commit --allow-empty -m \"First Commit\"");
+            repo.Execute("tag 1.0.0");
+            var firstCommitHash = repo.GetCurrentCommitHash();
+            repo.Execute("commit --allow-empty -m \"Second Commit\"");
+            repo.Execute("tag 2.0.0");
+            repo.Execute($"checkout {firstCommitHash}");
+            var latestTag = repo.GetLatestTag();
+            latestTag.Should().Be("1.0.0");
+        }
+    }
+
+    public void ShouldGetLatestTagHash()
+    {
+        using (var folder = new DisposableFolder())
+        {
+            var repo = folder.Init();
+            repo.Execute("commit --allow-empty -m \"First Commit\"");
+            repo.Execute("tag 1.0.0");
+            var latestTagHash = repo.GetLatestTagHash();
+            latestTagHash.Should().Be(repo.GetCurrentCommitHash());
+        }
+    }
+
+    public void ShouldReturnEmptyStringForLatestTagHash()
+    {
+        using (var folder = new DisposableFolder())
+        {
+            var repo = folder.Init();
+            repo.Execute("commit --allow-empty -m \"First Commit\"");
+            var latestTagHash = repo.GetLatestTagHash();
+            latestTagHash.Should().BeEmpty();
+        }
+    }
+
+    public void ShouldGetLatestTagHashFromCurrentCheckout()
+    {
+        using (var folder = new DisposableFolder())
+        {
+            var repo = folder.Init();
+            repo.Execute("commit --allow-empty -m \"First Commit\"");
+            repo.Execute("tag 1.0.0");
+            var firstCommitHash = repo.GetCurrentCommitHash();
+            repo.Execute("commit --allow-empty -m \"Second Commit\"");
+            repo.Execute("tag 2.0.0");
+            repo.Execute($"checkout {firstCommitHash}");
+            var latestTagHash = repo.GetLatestTagHash();
+            latestTagHash.Should().Be(firstCommitHash);
+        }
+    }
 
     public void ShouldDetectUntrackedFiles()
     {
@@ -118,4 +172,3 @@ public class GitTests
     }
 
 }
-

--- a/src/Dotnet.Build/Git.csx
+++ b/src/Dotnet.Build/Git.csx
@@ -60,7 +60,7 @@ public class GitRepository
 
     public string GetLatestTagHash()
     {
-        return Execute("rev-list --tags --max-count=1").StandardOut.RemoveNewLine();
+        return Execute($"rev-list --max-count=1 { GetLatestTag() }").StandardOut.RemoveNewLine();
     }
 
     public string GetUrlToPushOrigin()


### PR DESCRIPTION
GetLatestTagHash() uses rev-list with all tags, and as such ends up returning the commit with the latest date across the entire repo which also has a tag. This differs from GetLatestTag(), which gets the latest tag that is either on the current commit or any predecessor.

Teach GetLatestTagHash to only look at the current commit or any predecessor to match the behaviour of GetLatestTag. This also fixes IsTagCommit() and BuildContext.IsTagCommit, as they use GetLatestTagHash() to determine if the current commit is tagged.