### PR TITLE
feat: add async Pack overloads to DotNet class

### DIFF
--- a/src/Dotnet.Build.Tests/DotNetTests.csx
+++ b/src/Dotnet.Build.Tests/DotNetTests.csx
@@ -36,6 +36,15 @@ public class DotNetTests
         }
     }
 
+    public async Task ShouldPackProjectWithCommitHashAsync()
+    {
+        using (var projectFolder = new DisposableFolder())
+        {
+            await Command.ExecuteAsync("dotnet", $"new console -o {projectFolder.Path}");
+            await DotNet.PackAsync(projectFolder.Path, "123");
+        }
+    }
+
     //[OnlyThis]
     public void ShouldExecuteTests()
     {
@@ -403,6 +412,19 @@ public class DotNetTests
     }
 
     //[OnlyThis]
+    public async Task ShouldPackAsyncWithTagVersionWhenVersionAttributeIsMissing()
+    {
+        using (var projectFolder = new DisposableFolder())
+        {
+            await Command.ExecuteAsync("dotnet", $"new classlib -n TestLib -o {projectFolder.Path}", projectFolder.Path);
+            await DotNet.PackAsync(projectFolder.Path, projectFolder.Path);
+
+            string pathToNugetFile = FindFile(projectFolder.Path, "*.nupkg");
+            Path.GetFileName(pathToNugetFile).Should().Be($"TestLib.{BuildContext.LatestTag}.nupkg");
+        }
+    }
+
+    //[OnlyThis]
     public void ShouldPackWithVersionWhenVersionIsSpecified()
     {
         using (var projectFolder = new DisposableFolder())
@@ -421,6 +443,26 @@ public class DotNetTests
             string pathToNugetFile = FindFile(projectFolder.Path, "*.nupkg");
 
 
+            Path.GetFileName(pathToNugetFile).Should().Be($"TestLib.0.0.1.nupkg");
+        }
+    }
+
+    //[OnlyThis]
+    public async Task ShouldPackAsyncWithVersionWhenVersionIsSpecified()
+    {
+        using (var projectFolder = new DisposableFolder())
+        {
+            await Command.ExecuteAsync("dotnet", $"new classlib -n TestLib -o {projectFolder.Path}", projectFolder.Path);
+
+            var projectFile = FindFile(projectFolder.Path, "*.csproj");
+            var document = XDocument.Load(projectFile);
+            var propertyGroupElement = document.Descendants("PropertyGroup").Single();
+            var isPublishableElement = new XElement("Version", "0.0.1");
+            propertyGroupElement.Add(isPublishableElement);
+            document.Save(projectFile);
+            await DotNet.PackAsync(projectFolder.Path, projectFolder.Path);
+
+            string pathToNugetFile = FindFile(projectFolder.Path, "*.nupkg");
             Path.GetFileName(pathToNugetFile).Should().Be($"TestLib.0.0.1.nupkg");
         }
     }

--- a/src/Dotnet.Build/DotNet.csx
+++ b/src/Dotnet.Build/DotNet.csx
@@ -454,6 +454,13 @@ public static class DotNet
         }
     }
 
+    public static async Task PackAsync()
+    {
+        foreach (var packableProject in BuildContext.PackableProjects)
+        {
+            await PackAsync(Path.GetDirectoryName(packableProject), BuildContext.NuGetArtifactsFolder, BuildContext.CurrentShortCommitHash);
+        }
+    }
 
     public static void Pack(string pathToProjectFolder, string pathToPackageOutputFolder, string commitHash = "")
     {
@@ -475,6 +482,27 @@ public static class DotNet
 
 
         Command.Execute("dotnet", $"pack {pathToProjectFile} --configuration Release --output {pathToPackageOutputFolder} {commitHash} {versionProperty}");
+    }
+
+    public static async Task PackAsync(string pathToProjectFolder, string pathToPackageOutputFolder, string commitHash = "")
+    {
+        if (!string.IsNullOrWhiteSpace(commitHash))
+        {
+            commitHash = $" /property:CommitHash={commitHash} ";
+        }
+
+        string pathToProjectFile = FindProjectFile(pathToProjectFolder);
+
+        var document = XDocument.Load(pathToProjectFile);
+        var version = document.Descendants("Version").SingleOrDefault()?.Value;
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            version = BuildContext.LatestTag;
+        }
+
+        var versionProperty = $" /property:Version={version.Replace("v", string.Empty, StringComparison.OrdinalIgnoreCase)} ";
+
+        await Command.ExecuteAsync("dotnet", $"pack {pathToProjectFile} --configuration Release --output {pathToPackageOutputFolder} {commitHash} {versionProperty}");
     }
 
     public static void Push(string packagesFolder, string source = DefaultSource)


### PR DESCRIPTION
## Summary

- Added `PackAsync()` parameterless overload that iterates `BuildContext.PackableProjects` and awaits `PackAsync(...)` for each
- Added `PackAsync(string pathToProjectFolder, string pathToPackageOutputFolder, string commitHash = "")` overload that uses `Command.ExecuteAsync` instead of `Command.Execute`
- Added three async test methods mirroring the existing sync Pack tests

## Test plan

- [ ] `ShouldPackProjectWithCommitHashAsync` — verifies async pack runs without error
- [ ] `ShouldPackAsyncWithTagVersionWhenVersionAttributeIsMissing` — verifies version falls back to latest tag
- [ ] `ShouldPackAsyncWithVersionWhenVersionIsSpecified` — verifies explicit version in project file is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)