### PR TITLE
chore: bump version to 0.31.0

### DIFF
--- a/build/Dotnet.Build.nuspec
+++ b/build/Dotnet.Build.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Dotnet.Build</id>
     <title>Dotnet.Build</title>
-    <version>0.30.0</version>
+    <version>0.31.0</version>
     <description>Just a collection of dotnet-script compatible scripts to be used in build scripts.</description>
     <authors>Bernhard Richter</authors>
     <owners>Bernhard Richter</owners>


### PR DESCRIPTION
## Summary

- Bumps `Dotnet.Build.nuspec` version from `0.30.0` to `0.31.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)